### PR TITLE
Enhance Kubernetes configuration examples

### DIFF
--- a/server/deploy/kubernetes/README.md
+++ b/server/deploy/kubernetes/README.md
@@ -1,0 +1,43 @@
+# Example Kubernetes Configurations for TeamTalk-NG
+
+This directory contains example Kubernetes objects
+in YAML format for deploying TeamTalk-NG server to Kubernetes.
+
+## Usage
+
+All Kubernetes objects are categorized into directories based on component names.
+
+Please make sure to check and edit configmaps and secrets accordingly before applying them. If you want to keep your customizations separated from our example objects, consider to use [Kustomize][].
+
+1. Prepare a Kubernetes namespace for your deployment.
+For example, create a new namespace `teamtalk-ng`:
+
+```sh
+kubectl create ns teamtalk-ng
+```
+
+2. Deploy a component using `kubectl`:
+
+```sh
+kubectl apply -f ./db-mariadb
+kubectl apply -f ./redis
+kubectl apply -f ./db-proxy
+kubectl apply -f ./login
+kubectl apply -f ./route
+kubectl apply -f ./msg
+kubectl apply -f ./http-msg
+kubectl apply -f ./msfs
+kubectl apply -f ./file
+kubectl apply -f ./dashboard
+``
+
+3. Expose your services with Ingress or LoadBalancer:
+
+```sh
+kubectl apply -f ./export-ingress # using Ingress
+# or
+kubectl apply -f ./export-lb # using LoadBalancer services
+```
+
+
+[Kustomize]: https://kustomize.io/

--- a/server/deploy/kubernetes/db-mariadb/db-cm.yaml
+++ b/server/deploy/kubernetes/db-mariadb/db-cm.yaml
@@ -22,4 +22,3 @@ metadata:
 data:
   MYSQL_USER: teamtalk
   MYSQL_DATABASE: teamtalk
-  MYSQL_ROOT_RANDOM_PASSWORD: "yes"

--- a/server/deploy/kubernetes/db-mariadb/db-deploy.yaml
+++ b/server/deploy/kubernetes/db-mariadb/db-deploy.yaml
@@ -42,6 +42,9 @@ spec:
           - configMapRef:
               name: teamtalk-ng-db
         resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
           limits:
             memory: "512Mi"
             cpu: "500m"

--- a/server/deploy/kubernetes/db-mariadb/db-secret.yaml
+++ b/server/deploy/kubernetes/db-mariadb/db-secret.yaml
@@ -21,3 +21,4 @@ metadata:
     component: db
 stringData:
   MYSQL_PASSWORD: changeme
+  MYSQL_ROOT_PASSWORD: changeme

--- a/server/deploy/kubernetes/export-ingress/login-ing.yaml
+++ b/server/deploy/kubernetes/export-ingress/login-ing.yaml
@@ -20,6 +20,9 @@ metadata:
     app: teamtalk-ng
     component: login
 spec:
+  tls:
+  - hosts:
+    - teamtalk-ng-login
   rules:
   - host: teamtalk-ng-login
     http:

--- a/server/deploy/kubernetes/http-msg/http-msg-deploy.yaml
+++ b/server/deploy/kubernetes/http-msg/http-msg-deploy.yaml
@@ -39,8 +39,11 @@ spec:
         - http_msg_server
         workingDir: /var/local/teamtalk-ng
         resources:
+          requests:
+            memory: "64Mi"
+            cpu: "100m"
           limits:
-            memory: "512Mi"
+            memory: "128Mi"
             cpu: "500m"
         ports:
         - containerPort: 8400

--- a/server/deploy/kubernetes/msg/msg-deploy.yaml
+++ b/server/deploy/kubernetes/msg/msg-deploy.yaml
@@ -39,6 +39,9 @@ spec:
         - msg_server
         workingDir: /var/local/teamtalk-ng
         resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
           limits:
             memory: "512Mi"
             cpu: "500m"

--- a/server/deploy/kubernetes/redis/redis-deploy.yaml
+++ b/server/deploy/kubernetes/redis/redis-deploy.yaml
@@ -40,9 +40,12 @@ spec:
           - secretRef:
               name: teamtalk-ng-redis
         resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
           limits:
             memory: "512Mi"
-            cpu: "200m"
+            cpu: "500m"
         ports:
         - containerPort: 6379
           name: redis


### PR DESCRIPTION
1. Add README.
2. `MYSQL_ROOT_RANDOM_PASSWORD` doesn't seem to work. Specify a password in Secret instead.
3. Adjust requests and limits for some containers.
4. Enable HTTPS in login server ingress object.